### PR TITLE
Accept the 'include_deleted' parameter for changing scopes

### DIFF
--- a/app/api/v1/envelope_helpers.rb
+++ b/app/api/v1/envelope_helpers.rb
@@ -33,4 +33,8 @@ module EnvelopeHelpers
       delete => { accepted_schemas: [url(:api, :schemas, :delete_envelope)] }
     }
   end
+
+  def find_envelopes
+    Envelope.select_scope(params[:include_deleted]).in_community(community)
+  end
 end

--- a/app/models/envelope.rb
+++ b/app/models/envelope.rb
@@ -42,10 +42,21 @@ class Envelope < ActiveRecord::Base
   validates_with ResourceSchemaValidator, if: [:json?, :envelope_community]
 
   default_scope { where(deleted_at: nil) }
+  scope :deleted, -> { unscoped.where.not(deleted_at: nil) }
   scope :ordered_by_date, -> { order(created_at: :desc) }
   scope :in_community, (lambda do |community|
     joins(:envelope_community).where(envelope_communities: { name: community })
   end)
+
+  def self.select_scope(include_deleted = nil)
+    if include_deleted == 'true'
+      unscoped.all
+    elsif include_deleted == 'only'
+      deleted
+    else
+      all
+    end
+  end
 
   def_delegator :envelope_community, :name, :community_name
 

--- a/app/services/search.rb
+++ b/app/services/search.rb
@@ -12,8 +12,8 @@ module MetadataRegistry
     end
 
     def run
-      # by default match all
-      @query = Envelope.all
+      # default query scope
+      @query = Envelope.select_scope(include_deleted)
 
       # match by each method if they have valid entries
       query_methods.each { |method| send(:"search_#{method}") if send(method) }
@@ -27,6 +27,10 @@ module MetadataRegistry
     # filter methods
     def query_methods
       [:fts, :community, :type, :resource_type, :date_range]
+    end
+
+    def include_deleted
+      @include_deleted ||= params.delete(:include_deleted)
     end
 
     # full-text-search param

--- a/spec/api/v1/envelopes_spec.rb
+++ b/spec/api/v1/envelopes_spec.rb
@@ -229,6 +229,16 @@ describe API::V1::Envelopes do
       it { expect_status(:no_content) }
     end
 
+    context 'with invalid parameters' do
+      before(:each) do
+        put '/api/learning-registry/envelopes',
+            attributes_for(:delete_envelope).merge(delete_token_format: 'nope')
+      end
+
+      it { expect_status(:unprocessable_entity) }
+      it { expect_json('errors.0', /delete_token_format : Must be one of .*/) }
+    end
+
     context 'trying to delete a non existent envelope' do
       before(:each) do
         put '/api/learning-registry/envelopes',

--- a/spec/api/v1/single_envelope_spec.rb
+++ b/spec/api/v1/single_envelope_spec.rb
@@ -104,5 +104,15 @@ describe API::V1::SingleEnvelope do
         expect(envelope.deleted_at).not_to be_nil
       end
     end
+
+    context 'with invalid parameters' do
+      before(:each) do
+        delete "/api/learning-registry/envelopes/#{envelope.envelope_id}",
+               attributes_for(:delete_envelope).merge(delete_token_format: 'no')
+      end
+
+      it { expect_status(:unprocessable_entity) }
+      it { expect_json('errors.0', /delete_token_format : Must be one of .*/) }
+    end
   end
 end

--- a/spec/models/envelope_spec.rb
+++ b/spec/models/envelope_spec.rb
@@ -56,7 +56,7 @@ describe Envelope, type: :model do
       envelopes = [create(:envelope), create(:envelope)]
       expect(Envelope.count).to eq 2
 
-      envelopes.first.update_attribute(:deleted_at, Time.now)
+      envelopes.first.update_attribute(:deleted_at, Time.current)
       expect(Envelope.count).to eq 1
     end
   end
@@ -64,7 +64,7 @@ describe Envelope, type: :model do
   describe 'select_scope' do
     let!(:envelopes) { (0...3).map { create(:envelope) } }
 
-    before { envelopes.first.update_attribute(:deleted_at, Time.now) }
+    before { envelopes.first.update_attribute(:deleted_at, Time.current) }
 
     it 'uses default_scope if no param is given' do
       expect(Envelope.select_scope.count).to eq 2

--- a/spec/models/envelope_spec.rb
+++ b/spec/models/envelope_spec.rb
@@ -54,10 +54,28 @@ describe Envelope, type: :model do
   describe 'default_scope' do
     it 'Does not show deleted entries' do
       envelopes = [create(:envelope), create(:envelope)]
-      expect(Envelope.count).to be 2
+      expect(Envelope.count).to eq 2
 
       envelopes.first.update_attribute(:deleted_at, Time.now)
-      expect(Envelope.count).to be 1
+      expect(Envelope.count).to eq 1
+    end
+  end
+
+  describe 'select_scope' do
+    let!(:envelopes) { (0...3).map { create(:envelope) } }
+
+    before { envelopes.first.update_attribute(:deleted_at, Time.now) }
+
+    it 'uses default_scope if no param is given' do
+      expect(Envelope.select_scope.count).to eq 2
+    end
+
+    it 'gets all entries when include_deleted=true' do
+      expect(Envelope.select_scope('true').count).to eq 3
+    end
+
+    it 'gets only deleted etries when include_deleted=only' do
+      expect(Envelope.select_scope('only').count).to eq 1
     end
   end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -39,13 +39,6 @@ module Helpers
     jwt_encode(attributes_for(:resource), signed: false)
   end
 
-  def default_payload
-    {
-      email: 'me@example.org',
-      action: 'approve'
-    }
-  end
-
   #
   # Takes a regular envelope object and creates a couple of versions on it
   #


### PR DESCRIPTION
Closes #57 

this flag works the same across the search and all the envelopes API:
- `/api/cred-reg/search?include_deleted=true`
- `/api/cred-reg/search?include_deleted=only`
- `/api/cred-reg/envelopes?include_deleted=true`
- `/api/cred-reg/envelopes/{id-of-a-deleted-record}?include_deleted=true`
